### PR TITLE
Chore: Replace module

### DIFF
--- a/data_science_utils/plots/__init__.py
+++ b/data_science_utils/plots/__init__.py
@@ -11,7 +11,7 @@ from sklearn.metrics import mean_squared_error
 import seaborn as sns
 
 from sklearn.metrics import precision_recall_curve
-from sklearn.utils.fixes import signature
+from inspect import signature
 from sklearn.metrics import average_precision_score
 
 


### PR DESCRIPTION
While using the library, I got the error `ImportError: cannot import name signature from 'sklearn.utils.fixes'`.
I headed over to the [official repository](https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/fixes.py) and found that there is no method of `signature`. However, in **python3**, the `inspect` module does have a `signature` method. So replacing `'sklearn.utils.fixes` module with `inspect` module to make it work fine.